### PR TITLE
fix(logging): fix logger setup

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -57,7 +57,6 @@ func NewStandardLogger() (l *zap.Logger, err error) {
 			EncodeLevel:    zapcore.LowercaseLevelEncoder,
 			EncodeTime:     zapcore.ISO8601TimeEncoder,
 			EncodeDuration: zapcore.SecondsDurationEncoder,
-			EncodeCaller:   zapcore.ShortCallerEncoder,
 		},
 		OutputPaths:      []string{"stdout"},
 		ErrorOutputPaths: []string{"stderr"},


### PR DESCRIPTION
apparently Zap changed their API and not this isn't a field.