### PR TITLE
fix(middlewares): update statsd tags and reporting

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -2,11 +2,6 @@
 Package metrics adds prometheus metrics and registers a metrics handler on the
 /metrics endpoint.
 
-The default value for commit is "HEAD", but should be overwritten at compile
-time using the go link flag "-X" like so:
-
-	go build -ldflags="-X github.com/skuid/spec/metrics.commit=`git rev-parse --short HEAD`" main.go
-
 The package is only imported for the side effect of registering its HTTP
 handler and adding the included metrics. To use it this way, link this package
 into your program:
@@ -20,10 +15,10 @@ package metrics
 
 import (
 	"net/http"
-	"runtime"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/skuid/spec/version"
 )
 
 var (
@@ -36,13 +31,8 @@ var (
 	)
 )
 
-var (
-	commit  = "HEAD"
-	version = runtime.Version()
-)
-
 func init() {
-	versionGuauge.WithLabelValues(commit, version).Set(1)
+	versionGuauge.WithLabelValues(version.Commit, version.GoVersion).Set(1)
 	prometheus.MustRegister(versionGuauge)
 	http.Handle("/metrics", promhttp.Handler())
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,17 @@
+package version
+
+import "runtime"
+
+/*
+version creates exportable variables for the current commit hash and the golang runtime version.
+
+The default value for commit is "HEAD", but should be overwritten at compile
+time using the go link flag "-X" like so:
+
+	go build -ldflags="-X github.com/skuid/spec/version.Commit=`git rev-parse --short HEAD`"
+*/
+
+var (
+	Commit    = "HEAD"            // Commit is used to surface which commit is at the HEAD
+	GoVersion = runtime.Version() // GoVersion is used to surface which version of golang is being used
+)


### PR DESCRIPTION
Turns out that path and status code were getting dropped for some reason.

## Changelog

- create tags array to hold tags in format 'key:val'
- move commit and golang version to new pkg 'version' with exported variables
- use new version package in metrics and in middlewares to report commit sha
