### PR TITLE
feat(spec): fixing statsd prefix and global tags

### DIFF
--- a/middlewares/statsd.go
+++ b/middlewares/statsd.go
@@ -4,21 +4,23 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 )
 
-var statsdClient *statsd.Client
+var c *statsd.Client
 
 // InitClient accepts config parameters and builds the dogstatsd Client, accessible by the getter Client()
 // An error is returned only if a problem is encountered setting up the Client.
-func InitClient(host string, port string, prefix string) error {
+func InitClient(host string, port string, prefix string, globalTags []string) error {
 	var err error
-	statsdClient, err = statsd.New(host + ":" + port)
+	c, err = statsd.New(host + ":" + port)
 	if err != nil {
 		return err
 	}
-	statsdClient.Namespace = prefix
+	c.Tags = append(c.Tags, globalTags...)
+	c.Namespace = prefix + "."
+	c.Incr("server_start", []string(nil), 1)
 	return nil
 }
 
 // Client returns a pointer to the dogstatsd Client, useful for logging metrics
 func Client() *statsd.Client {
-	return statsdClient
+	return c
 }


### PR DESCRIPTION
Same treatment here as to pliny. Adding global tags to the mix and reporting counts on various kinds of status codes.