### PR TITLE
PLIN-2143 package level user context key with helper functions for both …

### DIFF
--- a/middlewares/context.go
+++ b/middlewares/context.go
@@ -1,0 +1,72 @@
+package middlewares
+
+// User context key is stored in spec so both spec & other packages importing spec can access & set user values in context
+// Context key types & values must match in ctx.Value, meaning keys have package uniquness.
+// Therefore if spec or other package wants ctx key value we must use these helper functions.
+// For example, we need user fields in our Logging middleware.
+
+import (
+	"context"
+	"errors"
+)
+
+type contextKey string
+
+var userContextKey = contextKey("user")
+
+// OrgIDFromContext retrieves an organization ID value stored in a context
+func OrgIDFromContext(ctx context.Context) (string, error) {
+	u := ctx.Value(userContextKey)
+	if u == nil {
+		return "", errors.New("User is not stored in given context")
+	}
+	orgID, ok := u.(map[string]interface{})["orgID"]
+	if !ok {
+		return "", errors.New("OrgID is not stored in given context")
+	}
+	orgIDString, ok := orgID.(string)
+	if !ok || orgIDString == "" {
+		return "", errors.New("OrgID not stored as string in given context")
+	}
+	return orgIDString, nil
+}
+
+// UserIDFromContext retrieves an organization ID value stored in a context
+func UserIDFromContext(ctx context.Context) (string, error) {
+	u := ctx.Value(userContextKey)
+	if u == nil {
+		return "", errors.New("User is not stored in given context")
+	}
+	v, ok := u.(map[string]interface{})["userID"]
+	if !ok {
+		return "", errors.New("UserID is not stored in given context")
+	}
+	vString, ok := v.(string)
+	if !ok || vString == "" {
+		return "", errors.New("userID not stored as string in given context")
+	}
+	return vString, nil
+}
+
+// ContextWithUser places a user ID value, org Id value, and admin bool into a context using the same context user key
+func ContextWithUser(ctx context.Context, userID string, orgID string, admin bool) context.Context {
+	userValues := map[string]interface{}{
+		"orgID":  orgID,
+		"userID": userID,
+		"admin":  admin,
+	}
+	return context.WithValue(ctx, userContextKey, userValues)
+}
+
+// IsAdminFromContext returns a boolean indicating whether the user is an admin or not
+func IsAdminFromContext(ctx context.Context) bool {
+	u := ctx.Value(userContextKey)
+	if u == nil {
+		return false
+	}
+
+	if v, ok := u.(map[string]interface{})["admin"]; !ok || v == false {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
…warden & spec to use

I couldn't solve the problem of adding user fields as baggage items to the span being created by muxtrace. The span was being created by muxtrace in TraceAndServe for the specific handler (ie Load). All of our core API middlewares run before that, so it was impossible to add these fields without adding the addFacetFields middleware directly to the handler middlewares, which was not ideal.

Instead, I am deciding to pull the user context key out of warden and add it to spec. Why? That way spec and warden can access the value stored in the context. Before, it was limited to warden since context keys have package level uniqueness. And due to the import cycle, spec can't use warden's helper funcs.

I am copying over the same helper funcs from `decorators.go` for setting/pulling values from our user context key: https://github.com/skuid/warden/blob/1b224c6ac9333a4f88e2eea598e0dcbf9a0beba4/pkg/api/decorators.go#L187. I will remove them after this is merged in & update warden to use spec's helper functions (ie `middlewares.UserFromContext`) rather than warden's (ie. `api.UserFromContext`).

This is how we access the span using the tracer package. It is simply stored in the context with a package level context key (activeSpanKey)that we can pull using some helper functions (https://github.com/DataDog/dd-trace-go/blob/ef2d8b4acdd7861bc0be01ac5696d9db129bee35/ddtrace/tracer/context.go).