### PR TITLE
PLIN-2143 make orgId a siteID field for zap logger

### DIFF
--- a/middlewares/middlewares.go
+++ b/middlewares/middlewares.go
@@ -114,7 +114,7 @@ func Logging(closures ...func(*http.Request) []zapcore.Field) Middleware {
 					fields = append(fields, zap.String("userId", userID))
 				}
 				if orgID, err := OrgIDFromContext(r.Context()); err == nil {
-					fields = append(fields, zap.String("orgID", orgID))
+					fields = append(fields, zap.String("siteID", orgID))
 				}
 				for _, f := range closures {
 					fields = append(fields, f(r)...)


### PR DESCRIPTION
After checking datadog, I was close but I used orgID instead of siteId so you can't filter on it 😢 

On the bright side, userId is available as a filter in datadog for warden test.