### PR TITLE
AB#442741: add `response_time` to request logs

### DIFF
--- a/middlewares/middlewares.go
+++ b/middlewares/middlewares.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -109,6 +110,7 @@ func Logging(closures ...func(*http.Request) []zapcore.Field) Middleware {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			wrappedWriter := &statusLoggingResponseWriter{w, http.StatusOK, 0}
+			requestTime := time.Now()
 
 			defer func() {
 				fields := []zapcore.Field{
@@ -119,6 +121,7 @@ func Logging(closures ...func(*http.Request) []zapcore.Field) Middleware {
 					zap.String("remote_addr", getRemoteAddr(r)),
 					zap.String("user_agent", r.Header.Get("User-Agent")),
 					zap.Int("body_bytes", wrappedWriter.bodyBytes),
+					zap.Int64("response_time", time.Since(requestTime).Milliseconds()),
 				}
 
 				if userID, err := UserIDFromContext(r.Context()); err == nil {

--- a/middlewares/middlewares_test.go
+++ b/middlewares/middlewares_test.go
@@ -115,7 +115,7 @@ func TestLoggingClosures(t *testing.T) {
 		t.Fatal("Expected log! Got no logs")
 	}
 	loggedMessage := observed.All()[0]
-	if loggedMessage.Context[7].String != "alfanzo" {
+	if loggedMessage.Context[8].String != "alfanzo" {
 		t.Errorf("Didn't find alfanzo")
 	}
 }


### PR DESCRIPTION
# Work Item URL
https://dev.azure.com/nintex/Nintex/_workitems/edit/442741

# Description
In the [Seaquill/Nautilus transition dashboard](https://app.datadoghq.com/dashboard/tkg-9bz-ed8/seaquillnautilus-transition-dashboard?fromUser=false&refresh_mode=sliding&from_ts=1746035149823&to_ts=1748627149823&live=true), we are adding a section to compare Seaquill request `response_time`'s to Nautilus request `response_time`'s. However, currently we only include the `response_time` in our Node service response logs. 

This PR updates our Golang spec request logs to include a calculated `response_time`, similar to how we store `response_time` for Node response logs.

Just to note, the Node services store a request and a response log, whereas our Golang services only store a request log. 